### PR TITLE
Undo loop detection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,3 @@
 RuneLite utility to make it easier to transcribe NPC dialogue onto the wiki. Example: https://oldschool.runescape.wiki/w/Maedhros#Dialogue
 
 Copies all NPC dialogue, player dialogue, dialogue options, and chosen options into a panel that can be copied from. This does minimal formatting – the end user still needs to do some stuff before it goes on the wiki.
-
-Instructions on use:
-1. Click the RESET button before initiating conversation with each different NPC.
-2. Do not use number keys to select options, only click.
-3. Spacebar is fine to advance dialogue, but if it is held down there will be messages skipped.

--- a/src/main/java/com/NpcDialogue/NpcDialoguePanel.java
+++ b/src/main/java/com/NpcDialogue/NpcDialoguePanel.java
@@ -27,7 +27,6 @@ package com.NpcDialogue;
 
 import java.awt.BorderLayout;
 import javax.swing.BorderFactory;
-import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
 import javax.swing.border.EmptyBorder;
@@ -40,11 +39,10 @@ class NpcDialoguePanel extends PluginPanel
 {
     private final JTextArea notesEditor = new JTextArea();
 
-    void init(NpcDialoguePlugin plugin)
+    void init()
     {
         getParent().setLayout(new BorderLayout());
         getParent().add(this, BorderLayout.CENTER);
-
 
         setLayout(new BorderLayout());
         setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
@@ -64,12 +62,6 @@ class NpcDialoguePanel extends PluginPanel
         notesContainer.add(notesEditor, BorderLayout.CENTER);
         notesContainer.setBorder(new EmptyBorder(10, 10, 10, 10));
 
-		JButton resetButton = new JButton("RESET");
-		resetButton.setSize(250, 25);
-		resetButton.addActionListener((ev) ->
-			plugin.reset());
-		add(resetButton, BorderLayout.CENTER);
-
         add(notesContainer, BorderLayout.CENTER);
     }
 
@@ -77,8 +69,4 @@ class NpcDialoguePanel extends PluginPanel
     {
         notesEditor.append(data.replaceAll("<br>", " ") + "\n");
     }
-
-	void setText(String data) {
-		notesEditor.setText(data.replaceAll("<br>", " ") + "\n");
-	}
 }

--- a/src/main/java/com/NpcDialogue/NpcDialoguePlugin.java
+++ b/src/main/java/com/NpcDialogue/NpcDialoguePlugin.java
@@ -24,12 +24,6 @@
  */
 package com.NpcDialogue;
 
-import com.NpcDialogue.node.DialogueNode;
-import com.NpcDialogue.node.MetaDialogueNode;
-import com.NpcDialogue.node.NPCDialogueNode;
-import com.NpcDialogue.node.OptionDialogueNode;
-import com.NpcDialogue.node.PlayerDialogueNode;
-import com.NpcDialogue.node.SelectDialogueNode;
 import javax.inject.Inject;
 import java.awt.image.BufferedImage;
 import net.runelite.api.Client;
@@ -59,20 +53,19 @@ public class NpcDialoguePlugin extends Plugin
     @Inject
     private ClientToolbar clientToolbar;
 
-    private String lastText = null;
+    private String lastNpcDialogueText = null;
+    private String lastPlayerDialogueText = null;
+    private String lastSpriteText = null;
     private Widget[] dialogueOptions;
     private NpcDialoguePanel panel;
     private NavigationButton navButton;
-
-	private DialogueNode rootNode = new DialogueNode("");
-	private DialogueNode curParentNode = rootNode;
 
     @Override
     public void startUp()
     {
         // Shamelessly copied from NotesPlugin
         panel = injector.getInstance(NpcDialoguePanel.class);
-        panel.init(this);
+        panel.init();
 
         // Hack to get around not having resources.
         final BufferedImage icon = ImageUtil.getResourceStreamFromClass(getClass(), "dialogue_icon.png");
@@ -99,7 +92,7 @@ public class NpcDialoguePlugin extends Plugin
             int actionParam = menuOptionClicked.getActionParam();
             // if -1, "Click here to continue"
             if (actionParam > 0 && actionParam < dialogueOptions.length) {
-				curParentNode = curParentNode.findOption(dialogueOptions[actionParam].getText());
+                panel.appendText("<chose " + dialogueOptions[actionParam].getText() + ">");
             }
         }
     }
@@ -108,135 +101,56 @@ public class NpcDialoguePlugin extends Plugin
     public void onGameTick(GameTick tick) {
         Widget npcDialogueTextWidget = client.getWidget(WidgetInfo.DIALOG_NPC_TEXT);
 
-        if (npcDialogueTextWidget != null && !npcDialogueTextWidget.getText().equals(lastText)) {
+        if (npcDialogueTextWidget != null && !npcDialogueTextWidget.getText().equals(lastNpcDialogueText)) {
             String npcText = npcDialogueTextWidget.getText();
-            lastText = npcText;
+            lastNpcDialogueText = npcText;
 
             String npcName = client.getWidget(WidgetInfo.DIALOG_NPC_NAME).getText();
-			curParentNode.addChild(new NPCDialogueNode(npcName, npcText));
-			printTree();
+            panel.appendText("* '''" + npcName + ":''' " + npcText);
         }
 
         // This should be in WidgetInfo under DialogPlayer, but isn't currently.
         Widget playerDialogueTextWidget = client.getWidget(WidgetInfo.DIALOG_PLAYER_TEXT);
 
-        if (playerDialogueTextWidget != null && !playerDialogueTextWidget.getText().equals(lastText)) {
+        if (playerDialogueTextWidget != null && !playerDialogueTextWidget.getText().equals(lastPlayerDialogueText)) {
             String playerText = playerDialogueTextWidget.getText();
-            lastText = playerText;
+            lastPlayerDialogueText = playerText;
 
-			curParentNode.addChild(new PlayerDialogueNode(playerText));
-			printTree();
+            panel.appendText("* '''Player:''' " + playerText);
         }
 
         Widget playerDialogueOptionsWidget = client.getWidget(WidgetID.DIALOG_OPTION_GROUP_ID, 1);
         if (playerDialogueOptionsWidget != null && playerDialogueOptionsWidget.getChildren() != dialogueOptions) {
             dialogueOptions = playerDialogueOptionsWidget.getChildren();
-
-			//Detect loop
-			boolean loop = false;
-			DialogueNode existingSelectNode = rootNode.findOption(dialogueOptions[0].getText());
-			int totalOptions = dialogueOptions.length - 1;
-			if(existingSelectNode != null) {
-				int matchingOptions = 0;
-				for (int i = 0; i < dialogueOptions.length - 1; i++) {
-					DialogueNode existingOption = existingSelectNode.findOption(dialogueOptions[i].getText());
-					if(existingOption != null) {
-						matchingOptions++;
-					}
-				}
-				if(matchingOptions == totalOptions || matchingOptions == totalOptions - 1) {
-					curParentNode.addChild(new MetaDialogueNode("{{tact|a previous option menu is displayed}}"));
-					loop = true;
-				}
-			}
-
-			if(loop) {
-				curParentNode = existingSelectNode;
-			} else {
-				DialogueNode selectNode = new SelectDialogueNode(dialogueOptions[0].getText());
-				//This lets us rewalk the tree after restarting dialogue
-				selectNode = curParentNode.addChild(selectNode);
-				curParentNode = selectNode;
-				for (int i = 1; i < dialogueOptions.length - 2; i++)
-				{
-					curParentNode.addChild(new OptionDialogueNode(dialogueOptions[i].getText()));
-				}
-			}
-			printTree();
+            panel.appendText("* {{tselect|" + dialogueOptions[0].getText() + "}}");
+            for (int i = 1; i < dialogueOptions.length - 2; i++) {
+                panel.appendText("* {{topt|" + dialogueOptions[i].getText() + "}}");
+            }
         }
 
         Widget spriteTextWidget = client.getWidget(WidgetInfo.DIALOG_SPRITE_TEXT);
-        if (spriteTextWidget != null && !spriteTextWidget.getText().equals(lastText)) {
+        if (spriteTextWidget != null && !spriteTextWidget.getText().equals(lastSpriteText)) {
             String spriteText = spriteTextWidget.getText();
-            lastText = spriteText;
+            lastSpriteText = spriteText;
             Widget spriteWidget = client.getWidget(WidgetInfo.DIALOG_SPRITE_SPRITE);
-			String itemName = "<!--Error-->";
-			int itemid = -1;
-			if(spriteWidget != null) {
-				itemName = client.getItemDefinition(spriteWidget.getItemId()).getName();
-				itemid = spriteWidget.getItemId();
-			}
-			curParentNode.addChild(new DialogueNode("{{tbox|<!--id: "+ itemid + "-->pic=" + itemName + " detail.png|" + spriteText + "}}"));
-			printTree();
+            int id = spriteWidget.getItemId();
+            panel.appendText("* {{tbox|pic=" + id + " detail.png|" + spriteText + "}}");
         }
 
         Widget msgTextWidget = client.getWidget(229, 1);
-        if (msgTextWidget != null && !msgTextWidget.getText().equals(lastText)) {
+        if (msgTextWidget != null && !msgTextWidget.getText().equals(lastSpriteText)) {
             String msgText = msgTextWidget.getText();
-            lastText = msgText;
-			curParentNode.addChild(new DialogueNode("{{tbox|" + msgText + "}}"));
-			printTree();
+            lastSpriteText = msgText;
+            panel.appendText("* {{tbox|" + msgText + "}}");
         }
 
         Widget doubleSpriteTextWidget = client.getWidget(11, 2);
-        if (doubleSpriteTextWidget != null && !doubleSpriteTextWidget.getText().equals(lastText)) {
+        if (doubleSpriteTextWidget != null && !doubleSpriteTextWidget.getText().equals(lastSpriteText)) {
             String doubleSpriteText = doubleSpriteTextWidget.getText();
-            lastText = doubleSpriteText;
-			Widget widget1 = client.getWidget(11, 1);
-			Widget widget2 = client.getWidget(11, 3);
-			String itemName1 = "<!--Error-->";
-			String itemName2 = "<!--Error-->";
-			int itemid1 = -1;
-			int itemid2 = -1;
-			if (widget1 != null) {
-				itemName1 = client.getItemDefinition(widget1.getItemId()).getName();
-				itemid1 = widget1.getItemId();
-			}
-			if (widget2 != null) {
-				itemName2 = client.getItemDefinition(widget2.getItemId()).getName();
-				itemid2 = widget2.getItemId();
-			}
-			curParentNode.addChild(new DialogueNode("{{tbox|<!--id: "+ itemid1 + "-->pic=" + itemName1 + " detail.png|<!--id: "+ itemid2 + "-->pic2=" + itemName2 + " detail.png|" + doubleSpriteText + "}}"));
-			printTree();
+            lastSpriteText = doubleSpriteText;
+            int id1 = client.getWidget(11, 1).getItemId();
+            int id2 = client.getWidget(11, 3).getItemId();
+            panel.appendText("* {{tbox|pic=" + id1 + " detail.png|pic2=" + id2 + " detail.png|" + doubleSpriteText + "}}");
         }
-
-		if (npcDialogueTextWidget == null
-			&& playerDialogueTextWidget == null
-			&& playerDialogueOptionsWidget == null
-			&& spriteTextWidget == null
-			&& msgTextWidget == null
-			&& doubleSpriteTextWidget == null
-			&& lastText != null
-		) {
-
-			printTree();
-			curParentNode = rootNode;
-			lastText = null;
-
-		}
     }
-
-	private void printTree() {
-		StringBuilder sb = new StringBuilder();
-		rootNode.print(sb, 1);
-		String playerName = client.getLocalPlayer().getName();
-		panel.setText(sb.toString().replaceAll(playerName, "[player name]"));
-	}
-
-	public void reset() {
-		rootNode = new DialogueNode("");
-		curParentNode = rootNode;
-		lastText = null;
-		panel.setText("");
-	}
 }


### PR DESCRIPTION
Loop detection can have lossy behavior in complex dialogue paths. For example, branches that have overlap in messages will reorder the output in a way that makes it impossible to determine the original message order.

For now I would prefer to have no loop detection, and if it is to be added back should be optional.