### PR TITLE
Update to use gameval-based values for widgets

### DIFF
--- a/src/main/java/com/NpcDialogue/NpcDialoguePlugin.java
+++ b/src/main/java/com/NpcDialogue/NpcDialoguePlugin.java
@@ -28,8 +28,7 @@ import javax.inject.Inject;
 import java.awt.image.BufferedImage;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
-import net.runelite.api.widgets.ComponentID;
-import net.runelite.api.widgets.InterfaceID;
+import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
@@ -115,19 +114,19 @@ public class NpcDialoguePlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick tick)
 	{
-		Widget npcDialogueTextWidget = client.getWidget(ComponentID.DIALOG_NPC_TEXT);
+		Widget npcDialogueTextWidget = client.getWidget(InterfaceID.ChatLeft.TEXT);
 		if (npcDialogueTextWidget != null && (lastDialogueType != DialogInterfaceType.NPC || !npcDialogueTextWidget.getText().equals(lastSeenText)))
 		{
 			lastDialogueType = DialogInterfaceType.NPC;
 			String npcText = npcDialogueTextWidget.getText();
 			lastSeenText = npcText;
 
-			String npcName = client.getWidget(ComponentID.DIALOG_NPC_NAME).getText();
+			String npcName = client.getWidget(InterfaceID.ChatLeft.NAME).getText();
 			panel.appendText("* '''" + npcName + ":''' " + npcText);
 		}
 
 		// This should be in WidgetInfo under DialogPlayer, but isn't currently.
-		Widget playerDialogueTextWidget = client.getWidget(ComponentID.DIALOG_PLAYER_TEXT);
+		Widget playerDialogueTextWidget = client.getWidget(InterfaceID.ChatRight.TEXT);
 		if (playerDialogueTextWidget != null && (lastDialogueType != DialogInterfaceType.PLAYER || !playerDialogueTextWidget.getText().equals(lastSeenText)))
 		{
 			lastDialogueType = DialogInterfaceType.PLAYER;
@@ -137,7 +136,7 @@ public class NpcDialoguePlugin extends Plugin
 			panel.appendText("* '''Player:''' " + playerText);
 		}
 
-		Widget playerDialogueOptionsWidget = client.getWidget(InterfaceID.DIALOG_OPTION, 1);
+		Widget playerDialogueOptionsWidget = client.getWidget(InterfaceID.CHATMENU, 1);
 		if (playerDialogueOptionsWidget != null && (lastDialogueType != DialogInterfaceType.OPTION || playerDialogueOptionsWidget.getChildren() != dialogueOptions))
 		{
 			lastDialogueType = DialogInterfaceType.OPTION;
@@ -158,13 +157,13 @@ public class NpcDialoguePlugin extends Plugin
 			panel.appendText("* {{tbox|" + msgText + "}}");
 		}
 
-		Widget objectBoxWidget = client.getWidget(ComponentID.DIALOG_SPRITE_TEXT);
+		Widget objectBoxWidget = client.getWidget(InterfaceID.Objectbox.TEXT);
 		if (objectBoxWidget != null && (lastDialogueType != DialogInterfaceType.OBJECT_BOX || !objectBoxWidget.getText().equals(lastSeenText)))
 		{
 			lastDialogueType = DialogInterfaceType.OBJECT_BOX;
 			String spriteText = objectBoxWidget.getText();
 			lastSeenText = spriteText;
-			Widget spriteWidget = client.getWidget(ComponentID.DIALOG_SPRITE_SPRITE);
+			Widget spriteWidget = client.getWidget(InterfaceID.Objectbox.ITEM);
 			int id = spriteWidget.getItemId();
 			panel.appendText("* {{tbox|pic=" + id + " detail.png|" + spriteText + "}}");
 			for (Widget child : objectBoxWidget.getParent().getChildren())

--- a/src/main/java/com/NpcDialogue/NpcDialoguePlugin.java
+++ b/src/main/java/com/NpcDialogue/NpcDialoguePlugin.java
@@ -125,7 +125,6 @@ public class NpcDialoguePlugin extends Plugin
 			panel.appendText("* '''" + npcName + ":''' " + npcText);
 		}
 
-		// This should be in WidgetInfo under DialogPlayer, but isn't currently.
 		Widget playerDialogueTextWidget = client.getWidget(InterfaceID.ChatRight.TEXT);
 		if (playerDialogueTextWidget != null && (lastDialogueType != DialogInterfaceType.PLAYER || !playerDialogueTextWidget.getText().equals(lastSeenText)))
 		{
@@ -136,7 +135,7 @@ public class NpcDialoguePlugin extends Plugin
 			panel.appendText("* '''Player:''' " + playerText);
 		}
 
-		Widget playerDialogueOptionsWidget = client.getWidget(InterfaceID.CHATMENU, 1);
+		Widget playerDialogueOptionsWidget = client.getWidget(InterfaceID.Chatmenu.OPTIONS);
 		if (playerDialogueOptionsWidget != null && (lastDialogueType != DialogInterfaceType.OPTION || playerDialogueOptionsWidget.getChildren() != dialogueOptions))
 		{
 			lastDialogueType = DialogInterfaceType.OPTION;
@@ -148,7 +147,7 @@ public class NpcDialoguePlugin extends Plugin
 			}
 		}
 
-		Widget msgTextWidget = client.getWidget(229, 1);
+		Widget msgTextWidget = client.getWidget(InterfaceID.Messagebox.TEXT);
 		if (msgTextWidget != null && (lastDialogueType != DialogInterfaceType.MESSAGE_BOX || !msgTextWidget.getText().equals(lastSeenText)))
 		{
 			lastDialogueType = DialogInterfaceType.MESSAGE_BOX;
@@ -169,7 +168,7 @@ public class NpcDialoguePlugin extends Plugin
 			for (Widget child : objectBoxWidget.getParent().getChildren())
 			{
 				// Object box with options
-				if (child.getId() == 12648448 && !child.getText().isEmpty() && !child.getText().equals("Click here to continue"))
+				if (child.getId() == InterfaceID.Objectbox.UNIVERSE && !child.getText().isEmpty() && !child.getText().equals("Click here to continue"))
 				{
 					String optionText = child.getText();
 					panel.appendText("* {{topt|" + optionText + "}}");
@@ -177,24 +176,24 @@ public class NpcDialoguePlugin extends Plugin
 			}
 		}
 
-		Widget doubleObjectBoxWidget = client.getWidget(11, 2);
+		Widget doubleObjectBoxWidget = client.getWidget(InterfaceID.ObjectboxDouble.TEXT);
 		if (doubleObjectBoxWidget != null && (lastDialogueType != DialogInterfaceType.DOUBLE_OBJECT_BOX || !doubleObjectBoxWidget.getText().equals(lastSeenText)))
 		{
 			lastDialogueType = DialogInterfaceType.DOUBLE_OBJECT_BOX;
 			String doubleObjectBoxText = doubleObjectBoxWidget.getText();
 			lastSeenText = doubleObjectBoxText;
-			int id1 = client.getWidget(11, 1).getItemId();
-			int id2 = client.getWidget(11, 3).getItemId();
+			int id1 = client.getWidget(InterfaceID.ObjectboxDouble.MODEL1).getItemId();
+			int id2 = client.getWidget(InterfaceID.ObjectboxDouble.MODEL2).getItemId();
 			panel.appendText("* {{tbox|pic=" + id1 + " detail.png|pic2=" + id2 + " detail.png|" + doubleObjectBoxText + "}}");
 		}
 
-		Widget spriteBoxWidget = client.getWidget(41484291);
+		Widget spriteBoxWidget = client.getWidget(InterfaceID.Graphicbox.TEXT);
 		if (spriteBoxWidget != null && (lastDialogueType != DialogInterfaceType.SPRITE_BOX || !spriteBoxWidget.getText().equals(lastSeenText)))
 		{
 			lastDialogueType = DialogInterfaceType.SPRITE_BOX;
 			String spriteBoxText = spriteBoxWidget.getText();
 			lastSeenText = spriteBoxText;
-			int spriteId = client.getWidget(41484290).getSpriteId();
+			int spriteId = client.getWidget(InterfaceID.Graphicbox.IMG).getSpriteId();
 			panel.appendText("* {{tbox|pic=" + spriteId + " icon.png|" + spriteBoxText + "}}");
 		}
 	}


### PR DESCRIPTION
Updates plugin to replace ComponentID and old InterfaceID-based values, as well as some bare values, with the new gameval-based InterfaceID values. Split into two commits for ease of review:

- ed7a9fb0bc364f8471eff92491e5e97133a668bf: Automated migration of InterfaceID and ComponentID values using abex's script
- 75f341961cda711d83a3358974f0e39d095a637f: Replaces bare values with gameval.InterfaceID constants