### PR TITLE
Ignore MessageBox text widget if hidden

### DIFF
--- a/src/main/java/com/NpcDialogue/NpcDialoguePlugin.java
+++ b/src/main/java/com/NpcDialogue/NpcDialoguePlugin.java
@@ -150,7 +150,7 @@ public class NpcDialoguePlugin extends Plugin
 		}
 
 		Widget msgTextWidget = client.getWidget(229, 1);
-		if (msgTextWidget != null && (lastDialogueType != DialogInterfaceType.MESSAGE_BOX || !msgTextWidget.getText().equals(lastSeenText)))
+		if (msgTextWidget != null && !msgTextWidget.isHidden() && (lastDialogueType != DialogInterfaceType.MESSAGE_BOX || !msgTextWidget.getText().equals(lastSeenText)))
 		{
 			lastDialogueType = DialogInterfaceType.MESSAGE_BOX;
 			String msgText = msgTextWidget.getText();


### PR DESCRIPTION

Resolves the duplicated message issue which we had previously been able to reliably reproduce.


Duplicated message issue reproduction steps:

* Use Larry's boat near Rellekka to travel to Weiss using the right click "Weiss" option.
* Search the skeleton by the cave entrance

This causes `{{tbox|}}` and `* {{tbox|pic=964 detail.png|pic2=526 detail.png|You check for a pulse, but she's dead.}}` to be printed to the plugin's side panel every game tick. 

This PR adds a check to only update `lastDialogueType` to `MESSAGE_BOX` if the message box text widget is not hidden.
 Adding this check prevents the repeated entry issue described above.